### PR TITLE
refactor: binary data transfer and DummyVNA realism

### DIFF
--- a/src/cmt_vna/testing.py
+++ b/src/cmt_vna/testing.py
@@ -103,7 +103,8 @@ class DummyVNA(VNA):
         s.read_termination = "\n"
         s.timeout = self.vna_timeout
         s.write("CALC:FORM SCOM\n")
-        s.write("FORM:DATA REAL\n")
+        s.write("FORM:BORD NORM\n")
+        s.write("FORM:DATA REAL,64\n")
         s.write("SENS1:AVER:COUN 1\n")
         s.write("SWE:TYPE LIN\n")
         s.write("TRIG:SOUR BUS\n")

--- a/src/cmt_vna/testing.py
+++ b/src/cmt_vna/testing.py
@@ -1,5 +1,4 @@
 import numpy as np
-import time
 
 from . import VNA
 
@@ -7,56 +6,81 @@ from . import VNA
 class DummyResource:
     """
     Dummy PyVisa.Resource class for testing purposes.
-    This class does not implement any real functionality.
-    It is used to test the VNA class without needing a real connection.
+    Parses SCPI write commands to track VNA state (npoints, fstart, fstop)
+    and responds to query commands with synthetic data.
     """
 
-    def __init__(self, *args, **kwargs):
-        pass
+    _DEFAULT_NPOINTS = 1000
+    _DEFAULT_FSTART = 1e6
+    _DEFAULT_FSTOP = 250e6
+
+    def __init__(self):
+        self.read_termination = None
+        self.timeout = None
+        self._npoints = self._DEFAULT_NPOINTS
+        self._fstart = self._DEFAULT_FSTART
+        self._fstop = self._DEFAULT_FSTOP
 
     def write(self, command):
-        pass
+        """Parse SCPI commands to track instrument state."""
+        cmd = command.strip()
+        if cmd.startswith("SENS1:FREQ:STAR"):
+            parts = cmd.split()
+            self._fstart = float(parts[1])
+        elif cmd.startswith("SENS1:FREQ:STOP"):
+            parts = cmd.split()
+            self._fstop = float(parts[1])
+        elif cmd.startswith("SENS1:SWE:POIN"):
+            parts = cmd.split()
+            self._npoints = int(float(parts[1]))
 
-    @property
-    def mock_query_command(self):
-        """
-        The command that the mock will respond to when queried.
-        This is used to simulate a query response.
-        """
-        return "CALC:TRAC:DATA:FDAT?"
+    def query(self, command):
+        """Respond to simple SCPI queries."""
+        cmd = command.strip()
+        if cmd == "*IDN?":
+            return "DummyVNA"
+        if cmd == "*OPC?":
+            return "1"
+        raise ValueError(f"Query command {command!r} not recognized by mock.")
 
-    def query_ascii_values(self, command, container=None, npoints=1000):
+    def query_binary_values(
+        self, command, datatype="d", is_big_endian=True, container=None
+    ):
         """
-        Simulate querying a value from the VNA. The mock only
-        implements the case where the request is for data. Thus
-        ``command'' must as specified in the attribute
-        `mock_query_command'. The data returned is complex-valued
-        where even indices correspond to the real part and odd indices
-        correspond to the imaginary part. The number of points returned
-        is therefore `2 * npoints'.
+        Simulate querying binary array data from the VNA.
+
+        Supports:
+        - CALC:TRAC:DATA:FDAT? : interleaved real/imag S11 data
+          (2 * npoints values, all zeros)
+        - SENS1:FREQ:DATA? : frequency array (npoints values)
 
         Parameters
         ----------
         command : str
-            Must be `mock_query_command'.
-        container : None
-            Not used in this mock implementation.
-        npoints : int
-            Half the number of points to return.
+            SCPI query command.
+        datatype : str
+            Data type format character (ignored in mock).
+        is_big_endian : bool
+            Byte order (ignored in mock).
+        container : callable or None
+            Container for the returned data (e.g. np.array).
 
         Returns
         -------
-        data : np.ndarray
+        data : np.ndarray or list
             Simulated data response from the VNA.
 
-        Raises
-        -------
-        ValueError
-            If the command is not `mock_query_command'.
         """
-        if command != self.mock_query_command:
-            raise ValueError(f"Command {command} not recognized by mock.")
-        return np.zeros(2 * npoints)
+        cmd = command.strip()
+        if cmd == "CALC:TRAC:DATA:FDAT?":
+            data = np.zeros(2 * self._npoints)
+        elif cmd == "SENS1:FREQ:DATA?":
+            data = np.linspace(self._fstart, self._fstop, self._npoints)
+        else:
+            raise ValueError(f"Command {command!r} not recognized by mock.")
+        if container is not None:
+            data = container(data)
+        return data
 
     def close(self):
         pass
@@ -64,61 +88,23 @@ class DummyResource:
 
 class DummyVNA(VNA):
     """
-    Basic Mock VNA for testing purposes. This class passes all methods.
-    Basic attributes are still set in the __init__ method.
+    Mock VNA for testing purposes. Uses DummyResource instead of a real
+    PyVISA connection. All base class methods work through the stateful
+    DummyResource, so the code paths match the real VNA as closely as
+    possible.
     """
 
     def _configure_vna(self):
         """
-        Override the _configure_vna method to do nothing, except
-        replacing the attribute `s' that communicates with the VNA with
-        a dummy resource that does nothng.
+        Override _configure_vna to use DummyResource instead of real
+        PyVISA, while still exercising the SCPI initialization writes.
         """
-        return DummyResource()
-
-    @property
-    def id(self):
-        """
-        Override the id property to return a dummy ID.
-        """
-        return "DummyVNA"
-
-    @property
-    def freqs(self):
-        """
-        Override the freqs property to calculate the frequencies
-        instead of reading from the VNA.
-
-        Returns:
-            np.ndarray: Array of frequencies.
-
-        """
-        try:
-            f = np.linspace(self.fstart, self.fstop, self.npoints)
-        except (AttributeError, TypeError):
-            f = None
-        return f
-
-    def wait_for_opc(self, wait=0, err=False):
-        """
-        Override the wait_for_opc method. Sleeps for `wait' seconds
-        and optionally raises a TimeoutError if `err' is True.
-        This is used to simulate the operation complete check.
-
-        Parameters
-        ----------
-        wait : float
-            Time to wait for the operation to complete in seconds.
-        err : bool
-            If True, raises an exception to simulate an error.
-
-        Raises
-        -------
-        TimeoutError
-           If `err' is True.
-
-        """
-        if wait > 0:
-            time.sleep(wait)
-        if err:
-            raise TimeoutError("Operation timed out")
+        s = DummyResource()
+        s.read_termination = "\n"
+        s.timeout = self.vna_timeout
+        s.write("CALC:FORM SCOM\n")
+        s.write("FORM:DATA REAL\n")
+        s.write("SENS1:AVER:COUN 1\n")
+        s.write("SWE:TYPE LIN\n")
+        s.write("TRIG:SOUR BUS\n")
+        return s

--- a/src/cmt_vna/vna.py
+++ b/src/cmt_vna/vna.py
@@ -80,6 +80,7 @@ class VNA:
 
         # settings
         s.write("CALC:FORM SCOM\n")  # get s11 as real and imag
+        s.write("FORM:DATA REAL\n")  # 64-bit binary transfer
         s.write("SENS1:AVER:COUN 1\n")  # number of averages
         # linear sweep instead of point by point
         s.write("SWE:TYPE LIN\n")
@@ -147,14 +148,12 @@ class VNA:
 
     @property
     def freqs(self):
-        freq = self.s.query_ascii_values(
-            "SENS1:FREQ:DATA?", container=np.array
+        return self.s.query_binary_values(
+            "SENS1:FREQ:DATA?",
+            datatype="d",
+            is_big_endian=True,
+            container=np.array,
         )
-        try:
-            f_array = np.array([float(i) for i in freq])
-        except (TypeError, ValueError):
-            f_array = None
-        return f_array
 
     @property
     def header(self):
@@ -254,14 +253,16 @@ class VNA:
         self.wait_for_opc()  # wait for operation complete
         if verbose:
             print("swept")
-        data = self.s.query_ascii_values(
-            "CALC:TRAC:DATA:FDAT?", container=np.array
+        data = self.s.query_binary_values(
+            "CALC:TRAC:DATA:FDAT?",
+            datatype="d",
+            is_big_endian=True,
+            container=np.array,
         )
         self.wait_for_opc()  # wait for operation complete
         if verbose:
             sweep_time = time.time() - t0
             print(f"{sweep_time:.2f} seconds to sweep.")
-        data = np.array([float(i) for i in data])  # change to complex floats
         data = data[0::2] + 1j * data[1::2]
         return data
 

--- a/src/cmt_vna/vna.py
+++ b/src/cmt_vna/vna.py
@@ -80,7 +80,8 @@ class VNA:
 
         # settings
         s.write("CALC:FORM SCOM\n")  # get s11 as real and imag
-        s.write("FORM:DATA REAL\n")  # 64-bit binary transfer
+        s.write("FORM:BORD NORM\n")  # big-endian binary transfer
+        s.write("FORM:DATA REAL,64\n")  # 64-bit binary transfer
         s.write("SENS1:AVER:COUN 1\n")  # number of averages
         # linear sweep instead of point by point
         s.write("SWE:TYPE LIN\n")

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -85,9 +85,11 @@ class TestDummyVNA:
         assert self.vna.power_dBm == -10
 
     def test_freqs_property(self):
-        """Test freqs property calculation."""
-        # Should return None when not properly configured
-        assert self.vna.freqs is None
+        """Test freqs property returns correct frequency array."""
+        # Before setup, returns DummyResource defaults
+        freqs = self.vna.freqs
+        assert isinstance(freqs, np.ndarray)
+        assert len(freqs) == 1000
 
         # Configure frequency range
         self.vna.fstart = 1e6
@@ -128,19 +130,8 @@ class TestDummyVNA:
         assert isinstance(header["freqs"], np.ndarray)
 
     def test_wait_for_opc(self):
-        """Test wait_for_opc method."""
-        # Should complete immediately with no error
+        """Test wait_for_opc method completes without error."""
         self.vna.wait_for_opc()
-
-        # Test with wait time
-        start_time = time.time()
-        self.vna.wait_for_opc(wait=0.1)
-        elapsed = time.time() - start_time
-        assert elapsed >= 0.1
-
-        # Test with error
-        with pytest.raises(TimeoutError):
-            self.vna.wait_for_opc(err=True)
 
     def test_measure_s11(self):
         """Test S11 measurement."""
@@ -349,25 +340,25 @@ class TestDummyVNA:
 class TestVNAEdgeCases:
     """Test edge cases and error conditions for VNA classes."""
 
-    def test_frequency_array_with_missing_params(self):
-        """Test freqs property when parameters are missing."""
+    def test_frequency_array_updates_with_params(self):
+        """Test freqs property updates when VNA parameters change."""
         vna = DummyVNA()
 
-        # Missing all parameters
-        assert vna.freqs is None
-
-        # Missing some parameters
-        vna.fstart = 1e6
-        assert vna.freqs is None
-
-        vna.fstop = 250e6
-        assert vna.freqs is None
-
-        # All parameters set
-        vna.npoints = 1000
+        # Before explicit setup, DummyResource returns its defaults
         freqs = vna.freqs
-        assert freqs is not None
         assert isinstance(freqs, np.ndarray)
+        assert len(freqs) == 1000
+
+        # Setting parameters updates the resource state via SCPI writes
+        vna.fstart = 50e6
+        vna.fstop = 200e6
+        vna.npoints = 500
+
+        freqs = vna.freqs
+        assert isinstance(freqs, np.ndarray)
+        assert len(freqs) == 500
+        np.testing.assert_allclose(freqs[0], 50e6)
+        np.testing.assert_allclose(freqs[-1], 200e6)
 
     def test_measure_s11_with_uninitialized_vna(self):
         """Test S11 measurement without proper setup."""
@@ -380,7 +371,7 @@ class TestVNAEdgeCases:
         assert len(s11) == 1000
 
     def test_header_with_none_values(self):
-        """Test header when some values are None."""
+        """Test header when VNA properties are not explicitly set."""
         vna = DummyVNA()
         header = vna.header
 
@@ -389,7 +380,8 @@ class TestVNAEdgeCases:
         assert header["npoints"] is None
         assert header["ifbw"] is None
         assert header["power_dBm"] is None
-        assert header["freqs"] is None
+        # freqs comes from the resource, which has defaults
+        assert isinstance(header["freqs"], np.ndarray)
 
 
 class TestVNAIntegration:


### PR DESCRIPTION
## Summary
- Switch VNA data queries from ASCII to IEEE 754 64-bit binary transfer (`FORM:DATA REAL`) for faster throughput
- Remove redundant `np.array([float(i) for i in ...])` conversions in `VNA.freqs` and `VNA.measure_S11`
- Rewrite `DummyResource` to be stateful — parses SCPI writes to track `npoints`/`fstart`/`fstop`, supports both `SENS1:FREQ:DATA?` and `CALC:TRAC:DATA:FDAT?`, adds `query()` for `*IDN?`/`*OPC?`
- Simplify `DummyVNA` by removing overrides for `freqs`, `wait_for_opc`, and `id` — base class code paths now exercise through `DummyResource`
- Fix numpy truthiness bug in `S911T.sparams` (`if not model` → `if model is None`)

## Test plan
- [x] All 36 tests pass locally
- [x] ruff check and format pass
- [ ] **Verify binary transfer on hardware** — byte order (`FORM:BORD NORM` = big-endian) and IEEE block header parsing need real-instrument validation before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)