### PR TITLE
refactor!: replace switch_network object with switch_fn callable

### DIFF
--- a/scripts/get_cable_network_sparameters.py
+++ b/scripts/get_cable_network_sparameters.py
@@ -42,7 +42,7 @@ sparams_to_find = ["VNAANT", "VNAN", "VNAO", "VNAS", "VNAL"]
 
 i = 0
 snw = SwitchNetwork()
-vna = VNA(ip="127.0.0.1", port=5025, switch_network=snw)
+vna = VNA(ip="127.0.0.1", port=5025, switch_fn=snw.switch)
 print(f"Connected to {vna.id}.")
 freq = vna.setup(
     fstart=args.fstart,

--- a/scripts/measure_s11.py
+++ b/scripts/measure_s11.py
@@ -60,7 +60,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 snw = SwitchNetwork()  # make switch network object
-vna = VNA(ip="127.0.0.1", port=5025, switch_network=snw)
+vna = VNA(ip="127.0.0.1", port=5025, switch_fn=snw.switch)
 print(f"Connected to {vna.id}.")
 
 freq = vna.setup(

--- a/src/cmt_vna/vna.py
+++ b/src/cmt_vna/vna.py
@@ -17,7 +17,7 @@ class VNA:
         port=PORT,
         timeout=1000,
         save_dir=Path("."),
-        switch_network=None,
+        switch_fn=None,
     ):
         """
         Class controlling Copper Mountain VNA.
@@ -35,9 +35,13 @@ class VNA:
         save_dir : Path or str
             Directory to save data to. Must be able to instantiate a Path
             object.
-        switch_network : picohost.PicoRFSwitch or None
-            Instance of SwitchNetwork to automatically switch the DUT or
-            standards. If None, assumes switching is done in another way.
+        switch_fn : Callable[[str], Any] or None
+            Callable invoked to route the RF signal to a given standard or
+            DUT. Called with the state name as a string (e.g. ``"VNAO"``,
+            ``"VNAANT"``) and expected to return a truthy value on success
+            or raise on hard failure. Returning falsy is treated as a
+            switch-failure by ``measure_OSL``. If None, OSL prompts for
+            manual switching and ``measure_ant``/``measure_rec`` raise.
 
         """
 
@@ -50,7 +54,7 @@ class VNA:
 
         self._clear_data()
         self.save_dir = Path(save_dir)
-        self.switch_nw = switch_network
+        self.switch_fn = switch_fn
 
         # configure and connect to VNA
         self.vna_ip = ip
@@ -282,13 +286,13 @@ class VNA:
         OSL = {}
         standards = ["VNAO", "VNAS", "VNAL"]  # set osl standard list
         for standard in standards:
-            if self.switch_nw is None:  # testing/manual osl measurements
+            if self.switch_fn is None:  # testing/manual osl measurements
                 print(f"connect {standard} and press enter")
                 input()
             # automatic osl measurements
             else:
-                sw = self.switch_nw.switch(standard)
-                if sw == 0:
+                sw = self.switch_fn(standard)
+                if not sw:
                     raise RuntimeError(
                         f"Failed to switch to {standard}. "
                         "Check the switch network."
@@ -316,8 +320,8 @@ class VNA:
         """
         Measure S11 of antenna. If measure_noise is True, also measures
         S11 of noise source. This is a convenience function that uses the
-        switch network to switch to the right DUT. It therefore requires
-        the switch_nw attribute to be set.
+        switch callable to route the RF signal to the right DUT. It
+        therefore requires the switch_fn attribute to be set.
 
         Parameters
         ----------
@@ -334,29 +338,29 @@ class VNA:
         Raises
         -------
         RuntimeError
-            If the attribute switch_nw is None.
+            If the attribute switch_fn is None.
 
         """
-        if self.switch_nw is None:
-            raise RuntimeError("No switch network set, cannot measure S11.")
+        if self.switch_fn is None:
+            raise RuntimeError("No switch_fn set, cannot measure S11.")
         s11 = {}
-        self.switch_nw.switch("VNAANT")  # switch to antenna
+        self.switch_fn("VNAANT")  # switch to antenna
         s11["ant"] = self.measure_S11()
         if measure_load:
             # switch to load (noise source off)
-            self.switch_nw.switch("VNANOFF")
+            self.switch_fn("VNANOFF")
             s11["load"] = self.measure_S11()
         if measure_noise:
             # switch to noise source
-            self.switch_nw.switch("VNANON")
+            self.switch_fn("VNANON")
             s11["noise"] = self.measure_S11()
         return s11
 
     def measure_rec(self):
         """
         Measure S11 of the receiver. This is a convenience function that uses
-        the switch network to switch to the right DUT. It therefore requires
-        the switch_nw attribute to be set.
+        the switch callable to route the RF signal to the receiver. It
+        therefore requires the switch_fn attribute to be set.
 
         Returns
         -------
@@ -367,13 +371,13 @@ class VNA:
         Raises
         -------
         RuntimeError
-            If the attribute switch_nw is None.
+            If the attribute switch_fn is None.
 
         """
-        if self.switch_nw is None:
-            raise RuntimeError("No switch network set, cannot measure S11.")
+        if self.switch_fn is None:
+            raise RuntimeError("No switch_fn set, cannot measure S11.")
         s11 = {}
-        self.switch_nw.switch("VNARF")  # switch to receiver
+        self.switch_fn("VNARF")  # switch to receiver
         s11["rec"] = self.measure_S11()
         return s11
 

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import pytest
 import tempfile
 import time
+from unittest.mock import MagicMock, call
 
-from picohost.testing import DummyPicoRFSwitch
 from cmt_vna.vna import IP, PORT
 from cmt_vna.testing import DummyVNA
 
@@ -14,16 +14,15 @@ class TestDummyVNA:
 
     def setup_method(self):
         """Set up test fixtures before each test method."""
-        self.switch_nw = DummyPicoRFSwitch(port="/dev/ttyUSB0")
-        self.switch_nw.connect()
-        self.vna = DummyVNA(switch_network=self.switch_nw)
+        self.switch_fn = MagicMock(return_value=True)
+        self.vna = DummyVNA(switch_fn=self.switch_fn)
 
     def test_initialization(self):
         """Test DummyVNA initialization."""
         assert self.vna.vna_ip == IP
         assert self.vna.vna_port == PORT
         assert self.vna.save_dir == Path(".")
-        assert self.vna.switch_nw is self.switch_nw
+        assert self.vna.switch_fn is self.switch_fn
         assert self.vna.data == {}
         assert self.vna.stds_meta == {}
 
@@ -37,7 +36,7 @@ class TestDummyVNA:
         assert vna.vna_port == 1234
         assert vna.vna_timeout == 5000000  # converted to milliseconds
         assert vna.save_dir == save_dir
-        assert vna.switch_nw is None  # No switch network by default
+        assert vna.switch_fn is None  # No switch_fn by default
 
     def test_id_property(self):
         """Test the id property returns expected value."""
@@ -158,9 +157,9 @@ class TestDummyVNA:
         s11_verbose = self.vna.measure_S11(verbose=True)
         assert np.array_equal(s11, s11_verbose)
 
-    def test_measure_osl_without_switch_network(self, monkeypatch):
-        """Test OSL measurement without switch network (manual mode)."""
-        self.vna.switch_nw = None  # ensure no switch network is set
+    def test_measure_osl_without_switch_fn(self, monkeypatch):
+        """Test OSL measurement without switch_fn (manual mode)."""
+        self.vna.switch_fn = None  # ensure no switch_fn is set
         self.vna.setup(1e6, 250e6, 1000, 100, -5)
 
         # Mock input() to simulate user pressing enter
@@ -177,10 +176,9 @@ class TestDummyVNA:
             assert len(std) == 1000
             assert std.dtype == complex
 
-    def test_measure_osl_with_switch_network(self, mocker):
-        """Test OSL measurement with switch network."""
+    def test_measure_osl_with_switch_fn(self):
+        """Test OSL measurement with switch_fn."""
         self.vna.setup(1e6, 250e6, 1000, 100, -5)
-        spy = mocker.spy(self.vna.switch_nw, "switch")
 
         osl = self.vna.measure_OSL()
         assert isinstance(osl, dict)
@@ -191,15 +189,18 @@ class TestDummyVNA:
             assert data.dtype == complex
             assert np.all(data == 0)  # DummyResource returns zeros
 
-        # Verify switch network was called correctly
-        assert spy.call_count == 3
-        spy.assert_has_calls(
-            [
-                mocker.call("VNAO"),
-                mocker.call("VNAS"),
-                mocker.call("VNAL"),
-            ]
+        # Verify switch_fn was called correctly
+        assert self.switch_fn.call_count == 3
+        self.switch_fn.assert_has_calls(
+            [call("VNAO"), call("VNAS"), call("VNAL")]
         )
+
+    def test_measure_osl_switch_fn_failure_raises(self):
+        """measure_OSL raises RuntimeError when switch_fn returns falsy."""
+        self.vna.setup(1e6, 250e6, 1000, 100, -5)
+        self.vna.switch_fn = MagicMock(return_value=False)
+        with pytest.raises(RuntimeError, match="Failed to switch"):
+            self.vna.measure_OSL()
 
     def test_add_osl(self, monkeypatch):
         """Test add_OSL method."""
@@ -214,27 +215,22 @@ class TestDummyVNA:
         assert isinstance(self.vna.data["test_std"], np.ndarray)
         assert self.vna.data["test_std"].shape == (3, 1000)
 
-    def test_measure_ant_without_switch_network(self):
-        """Test antenna measurement without switch network raises error."""
-        self.vna.switch_nw = None  # ensure no switch network is set
-        with pytest.raises(RuntimeError, match="No switch network set"):
+    def test_measure_ant_without_switch_fn(self):
+        """Test antenna measurement without switch_fn raises error."""
+        self.vna.switch_fn = None  # ensure no switch_fn is set
+        with pytest.raises(RuntimeError, match="No switch_fn set"):
             self.vna.measure_ant()
 
-    def test_measure_ant_with_switch_network(self, mocker):
-        """Test antenna measurement with switch network."""
+    def test_measure_ant_with_switch_fn(self):
+        """Test antenna measurement with switch_fn."""
         self.vna.setup(1e6, 250e6, 1000, 100, -5)
-        spy = mocker.spy(self.vna.switch_nw, "switch")
 
         # Test with noise measurement
         s11 = self.vna.measure_ant(measure_noise=True)
 
-        assert spy.call_count == 3
-        spy.assert_has_calls(
-            [
-                mocker.call("VNAANT"),
-                mocker.call("VNANOFF"),
-                mocker.call("VNANON"),
-            ]
+        assert self.switch_fn.call_count == 3
+        self.switch_fn.assert_has_calls(
+            [call("VNAANT"), call("VNANOFF"), call("VNANON")]
         )
 
         assert "ant" in s11
@@ -245,32 +241,27 @@ class TestDummyVNA:
         assert isinstance(s11["noise"], np.ndarray)
 
         # Test without noise measurement
-        spy.reset_mock()
+        self.switch_fn.reset_mock()
         s11_no_noise = self.vna.measure_ant(
             measure_load=False, measure_noise=False
         )
-        assert spy.call_count == 1
-        spy.assert_has_calls(
-            [
-                mocker.call("VNAANT"),
-            ]
-        )
+        assert self.switch_fn.call_count == 1
+        self.switch_fn.assert_has_calls([call("VNAANT")])
 
         assert "ant" in s11_no_noise
         assert "noise" not in s11_no_noise
 
-    def test_measure_rec_without_switch_network(self):
-        """Test receiver measurement without switch network raises error."""
-        self.vna.switch_nw = None  # ensure no switch network is set
-        with pytest.raises(RuntimeError, match="No switch network set"):
+    def test_measure_rec_without_switch_fn(self):
+        """Test receiver measurement without switch_fn raises error."""
+        self.vna.switch_fn = None  # ensure no switch_fn is set
+        with pytest.raises(RuntimeError, match="No switch_fn set"):
             self.vna.measure_rec()
 
-    def test_measure_rec_with_switch_network(self, mocker):
-        """Test receiver measurement with switch network."""
+    def test_measure_rec_with_switch_fn(self):
+        """Test receiver measurement with switch_fn."""
         self.vna.setup(1e6, 250e6, 1000, 100, -5)
-        spy = mocker.spy(self.vna.switch_nw, "switch")
         s11 = self.vna.measure_rec()
-        spy.assert_called_once_with("VNARF")
+        self.switch_fn.assert_called_once_with("VNARF")
         assert "rec" in s11
         assert isinstance(s11["rec"], np.ndarray)
 


### PR DESCRIPTION
## Summary

- `VNA.__init__` now takes `switch_fn: Callable[[str], Any]` instead of a `switch_network` object. cmt_vna no longer depends on picohost's type space (the old `switch_network : picohost.PicoRFSwitch or None` docstring reached into a sibling package).
- Three call sites updated: `measure_OSL`, `measure_ant`, `measure_rec` invoke `self.switch_fn(state)` instead of `self.switch_nw.switch(state)`.
- `measure_OSL` raises `RuntimeError` if the callable returns falsy (same as old `sw == 0` semantics); `measure_ant`/`measure_rec` raise if `switch_fn is None`.
- Tests use `unittest.mock.MagicMock(return_value=True)` as the callable directly — no more `DummyPicoRFSwitch` import.
- Scripts (`measure_s11.py`, `get_cable_network_sparameters.py`) pass `snw.switch` (the bound method) instead of the `SwitchNetwork` object.

## Motivation

eigsep_observing now talks to RF-switch picos through Redis via `picohost.PicoManager` (see [eigsep_observing#42](https://github.com/EIGSEP/eigsep_observing/pull/42)). That flow returns a thin `PicoProxy` — not a full `PicoRFSwitch`. Accepting a callable lets cmt_vna work with both the direct device (`snw.switch`) and the proxy (`lambda s: proxy.send_command("switch", state=s)`) without a class-hierarchy shim on the picohost side.

## BREAKING CHANGE

`VNA.__init__` parameter renamed `switch_network` → `switch_fn`, and the `VNA.switch_nw` attribute renamed to `VNA.switch_fn`. Callers must pass a callable `(state: str) -> Any` rather than a switch-network object. For the typical picohost case that's just `snw.switch`.

## Test plan

- [x] `pytest` — 37/37 pass
- [x] `ruff check .` and `ruff format --check .` clean
- [ ] Real-hardware smoke test: run `scripts/measure_s11.py` against a live VNA + switch network (deferred to staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)