### PR TITLE
refactor: switch_fn contract is raises-on-failure, not truthy-return

### DIFF
--- a/src/cmt_vna/vna.py
+++ b/src/cmt_vna/vna.py
@@ -61,10 +61,10 @@ class VNA:
         switch_fn : Callable[[str], Any] or None
             Callable invoked to route the RF signal to a given standard or
             DUT. Called with the state name as a string (e.g. ``"VNAO"``,
-            ``"VNAANT"``) and expected to return a truthy value on
-            success. A falsy return is treated as a switch failure and
-            raised as ``RuntimeError`` by every ``measure_*`` method that
-            uses ``switch_fn`` — never silently ignored, because an
+            ``"VNAANT"``). The contract is "raises on failure": a normal
+            return (any value, including ``None``) indicates the switch
+            succeeded, and any exception propagates out of the enclosing
+            ``measure_*`` call — never silently ignored, because an
             unreported failed switch would contaminate the subsequent S11
             measurement. If None, OSL prompts for manual switching and
             ``measure_ant``/``measure_rec`` raise.
@@ -293,23 +293,6 @@ class VNA:
         data = data[0::2] + 1j * data[1::2]
         return data
 
-    def _switch_or_raise(self, state):
-        """Call ``self.switch_fn(state)`` and raise if it reports failure.
-
-        The single enforcement point for the ``switch_fn`` contract:
-        every internal switch call must go through here so a new caller
-        cannot accidentally skip the check. A falsy return (``False``,
-        ``None``, empty dict, ...) is treated as a hard failure and
-        raises ``RuntimeError`` — silently continuing would contaminate
-        the following S11 measurement.
-        """
-        sw = self.switch_fn(state)
-        if not sw:
-            raise RuntimeError(
-                f"Failed to switch to {state}. Check the switch network."
-            )
-        return sw
-
     def measure_OSL(self):
         """
         Iterate through all standards for measurement.
@@ -322,8 +305,9 @@ class VNA:
 
         Raises
         -------
-        RuntimeError
-            If ``switch_fn`` is set and returns falsy for any standard.
+        Exception
+            Any exception raised by ``switch_fn`` propagates, aborting
+            the OSL sequence before the subsequent S11 measurement.
 
         """
 
@@ -334,7 +318,7 @@ class VNA:
                 print(f"connect {standard} and press enter")
                 input()
             else:
-                self._switch_or_raise(standard)
+                self.switch_fn(standard)
             data = self.measure_S11()
             OSL[standard] = data
         return OSL
@@ -378,22 +362,24 @@ class VNA:
         Raises
         -------
         RuntimeError
-            If the attribute switch_fn is None, or if ``switch_fn``
-            returns falsy for any requested state.
+            If the attribute switch_fn is None.
+        Exception
+            Any exception raised by ``switch_fn`` propagates, aborting
+            the sequence before the corresponding S11 measurement.
 
         """
         if self.switch_fn is None:
             raise RuntimeError("No switch_fn set, cannot measure S11.")
         s11 = {}
-        self._switch_or_raise("VNAANT")  # switch to antenna
+        self.switch_fn("VNAANT")  # switch to antenna
         s11["ant"] = self.measure_S11()
         if measure_load:
             # switch to load (noise source off)
-            self._switch_or_raise("VNANOFF")
+            self.switch_fn("VNANOFF")
             s11["load"] = self.measure_S11()
         if measure_noise:
             # switch to noise source
-            self._switch_or_raise("VNANON")
+            self.switch_fn("VNANON")
             s11["noise"] = self.measure_S11()
         return s11
 
@@ -412,14 +398,16 @@ class VNA:
         Raises
         -------
         RuntimeError
-            If the attribute switch_fn is None, or if ``switch_fn``
-            returns falsy for the receiver state.
+            If the attribute switch_fn is None.
+        Exception
+            Any exception raised by ``switch_fn`` propagates, aborting
+            before the S11 measurement.
 
         """
         if self.switch_fn is None:
             raise RuntimeError("No switch_fn set, cannot measure S11.")
         s11 = {}
-        self._switch_or_raise("VNARF")  # switch to receiver
+        self.switch_fn("VNARF")  # switch to receiver
         s11["rec"] = self.measure_S11()
         return s11
 

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -14,7 +14,7 @@ class TestDummyVNA:
 
     def setup_method(self):
         """Set up test fixtures before each test method."""
-        self.switch_fn = MagicMock(return_value=True)
+        self.switch_fn = MagicMock()
         self.vna = DummyVNA(switch_fn=self.switch_fn)
 
     def test_initialization(self):
@@ -186,44 +186,44 @@ class TestDummyVNA:
             [call("VNAO"), call("VNAS"), call("VNAL")]
         )
 
-    def test_measure_osl_switch_fn_failure_raises(self):
-        """measure_OSL raises RuntimeError when switch_fn returns falsy."""
+    def test_measure_osl_switch_fn_failure_propagates(self):
+        """measure_OSL propagates exceptions raised by switch_fn."""
         self.vna.setup(1e6, 250e6, 1000, 100, -5)
-        self.vna.switch_fn = MagicMock(return_value=False)
-        with pytest.raises(RuntimeError, match="Failed to switch"):
+        self.vna.switch_fn = MagicMock(side_effect=RuntimeError("switch boom"))
+        with pytest.raises(RuntimeError, match="switch boom"):
             self.vna.measure_OSL()
 
-    @pytest.mark.parametrize("falsy", [False, None, 0, "", {}])
-    def test_measure_ant_switch_fn_failure_raises(self, falsy):
-        """measure_ant raises RuntimeError on the very first falsy
-        switch_fn return instead of silently proceeding to measure_S11
-        — a failed switch would otherwise contaminate the S11 data.
+    def test_measure_ant_switch_fn_failure_propagates(self):
+        """measure_ant propagates the very first switch_fn exception
+        instead of silently proceeding to measure_S11 — a failed switch
+        would otherwise contaminate the S11 data.
         """
         self.vna.setup(1e6, 250e6, 1000, 100, -5)
-        self.vna.switch_fn = MagicMock(return_value=falsy)
-        with pytest.raises(RuntimeError, match="Failed to switch to VNAANT"):
+        self.vna.switch_fn = MagicMock(side_effect=RuntimeError("switch boom"))
+        with pytest.raises(RuntimeError, match="switch boom"):
             self.vna.measure_ant()
         # The subsequent load/noise switches must not be attempted.
         self.vna.switch_fn.assert_called_once_with("VNAANT")
 
-    def test_measure_ant_switch_fn_failure_on_load_raises(self):
+    def test_measure_ant_switch_fn_failure_on_load_propagates(self):
         """Contract is enforced on every ``switch_fn`` call, not only
-        the first — a mid-sequence falsy return (e.g. switch to VNANOFF)
+        the first — a mid-sequence exception (e.g. switch to VNANOFF)
         aborts before the load S11 is recorded.
         """
         self.vna.setup(1e6, 250e6, 1000, 100, -5)
-        # truthy for VNAANT, falsy for VNANOFF
-        self.vna.switch_fn = MagicMock(side_effect=[True, False])
-        with pytest.raises(RuntimeError, match="Failed to switch to VNANOFF"):
+        # succeed for VNAANT, raise for VNANOFF
+        self.vna.switch_fn = MagicMock(
+            side_effect=[None, RuntimeError("load switch boom")]
+        )
+        with pytest.raises(RuntimeError, match="load switch boom"):
             self.vna.measure_ant(measure_noise=False, measure_load=True)
         assert self.vna.switch_fn.call_count == 2
 
-    @pytest.mark.parametrize("falsy", [False, None, 0, "", {}])
-    def test_measure_rec_switch_fn_failure_raises(self, falsy):
-        """measure_rec raises RuntimeError on a falsy switch_fn return."""
+    def test_measure_rec_switch_fn_failure_propagates(self):
+        """measure_rec propagates exceptions raised by switch_fn."""
         self.vna.setup(1e6, 250e6, 1000, 100, -5)
-        self.vna.switch_fn = MagicMock(return_value=falsy)
-        with pytest.raises(RuntimeError, match="Failed to switch to VNARF"):
+        self.vna.switch_fn = MagicMock(side_effect=RuntimeError("switch boom"))
+        with pytest.raises(RuntimeError, match="switch boom"):
             self.vna.measure_rec()
         self.vna.switch_fn.assert_called_once_with("VNARF")
 


### PR DESCRIPTION
## Summary
- Drop `_switch_or_raise` and the truthy-gate enforcement added in e0e1d2a. `measure_OSL` / `measure_ant` / `measure_rec` call `self.switch_fn` directly; any exception propagates and aborts before the subsequent S11 sweep. Return values are ignored — idiomatic `None`-returning callables (e.g. `PicoRFSwitch.switch`) now work as `switch_fn` without a bool-returning wrapper.
- Remove the `MagicMock(return_value=True)` bandage from the shared test fixture. Rewrite the four falsy-return tests as "exception propagates" equivalents, including the mid-sequence case (VNAANT succeeds, VNANOFF raises) that verifies we abort before recording the load S11. The `@parametrize("falsy", [False, None, 0, "", {}])` sweeps are gone — there's no longer a notion of "falsy switch failure" to enumerate.
- `measure_ant` / `measure_rec` still raise `RuntimeError("No switch_fn set...")` when `switch_fn is None` — that's an API precondition, not a switch failure.

## Breaking change
`switch_fn` callables that previously returned `False` to signal failure will now be treated as successful. Downstream callers must raise on failure instead. The intended callers in the EIGSEP stack (`PicoRFSwitch.switch`, `DummyPicoRFSwitch.switch`) already raise, so no picohost changes are needed.

## Test plan
- [x] `python -m pytest tests/test_vna.py -v` — 42/42 pass
- [x] `ruff check .` and `ruff format --check .` — clean
- [ ] Smoke-test against real `PicoRFSwitch.switch` on hardware to confirm the raising path still aborts cleanly mid-sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)