### PR TITLE
ci: bump Python matrix to 3.10-3.13 for trixie migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Three modules in `src/cmt_vna/`:
 ## Code Style
 
 - **ruff** for linting and formatting, 79-char line length
-- No type hints (targets Python 3.9+ without typing imports)
+- No type hints (targets Python 3.10+ without typing imports)
 - F401 (unused imports) suppressed in `__init__.py`
 - `scripts/lab_test_scripts/`, `examples/`, and `*.ipynb` are excluded from linting
 
@@ -51,7 +51,7 @@ Three modules in `src/cmt_vna/`:
 - Tests use `DummyVNA`/`DummyResource` — no hardware needed
 - pytest-timeout set to 60s per test
 - Coverage reports via pytest-cov (uploaded to Codecov in CI)
-- CI runs against Python 3.9, 3.10, 3.11, 3.12
+- CI runs against Python 3.10, 3.11, 3.12, 3.13
 
 ## Release Process
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   { name="Charlie Tolley", email="tolley412e@berkeley.edu" },
   { name="Christian Hellum Bye", email="cbh@berkeley.edu" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary
- Add Python 3.13 to the CI test matrix and drop 3.9 (EOL; no consumer requires it).
- Raise `requires-python` floor from `>=3.9` to `>=3.10` consistently with the matrix.
- Part of the coordinated trixie / Python 3.13 migration of the eigsep field stack (the CMT VNA manufacturer software requires Debian trixie, whose system Python is 3.13).

## Test plan
- [x] `ruff check .` and `ruff format --check .` clean on Python 3.13.
- [x] `pytest` green locally on Python 3.13 (51 passed, 91% coverage).
- [x] CI green on 3.10, 3.11, 3.12, 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)