### PR TITLE
feat: add generic measure_dut for arbitrary switch paths

### DIFF
--- a/src/cmt_vna/vna.py
+++ b/src/cmt_vna/vna.py
@@ -411,6 +411,39 @@ class VNA:
         s11["rec"] = self.measure_S11()
         return s11
 
+    def measure_dut(self, state):
+        """
+        Measure S11 of an arbitrary DUT selected by switch path name.
+
+        Generic companion to ``measure_ant`` / ``measure_rec``: uses
+        the switch callable to route the RF signal to ``state``, then
+        takes one S11 sweep. Use for paths that have no dedicated
+        convenience method (e.g. ``VNAAMB``, ``VNASP1``).
+
+        Parameters
+        ----------
+        state : str
+            Switch path name, passed verbatim to ``switch_fn``.
+
+        Returns
+        -------
+        s11 : np.ndarray
+            Complex S11 sweep of the selected DUT.
+
+        Raises
+        -------
+        RuntimeError
+            If the attribute switch_fn is None.
+        Exception
+            Any exception raised by ``switch_fn`` propagates, aborting
+            before the S11 measurement.
+
+        """
+        if self.switch_fn is None:
+            raise RuntimeError("No switch_fn set, cannot measure S11.")
+        self.switch_fn(state)
+        return self.measure_S11()
+
     def activeflag(self, data, cal, thresholds=None):
         """
         Sanity-check field calibration and measurement S11 dictionaries.

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 import tempfile
 import time
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 from cmt_vna.vna import IP, PORT, DEFAULT_FLAG_THRESHOLDS, lin2dB, mlin
 from cmt_vna.testing import DummyVNA
@@ -289,6 +289,33 @@ class TestDummyVNA:
         self.switch_fn.assert_called_once_with("VNARF")
         assert "rec" in s11
         assert isinstance(s11["rec"], np.ndarray)
+
+    def test_measure_dut_routes_switch_and_returns_sweep(self):
+        """measure_dut switches to the named path, then sweeps."""
+        self.vna.setup(1e6, 250e6, 1000, 100, -5)
+        s11 = self.vna.measure_dut("VNAAMB")
+        self.switch_fn.assert_called_once_with("VNAAMB")
+        assert isinstance(s11, np.ndarray)
+        assert s11.shape == (1000,)
+
+    def test_measure_dut_without_switch_fn(self):
+        """measure_dut without switch_fn raises, like measure_ant."""
+        self.vna.switch_fn = None
+        with pytest.raises(RuntimeError, match="No switch_fn set"):
+            self.vna.measure_dut("VNAAMB")
+
+    def test_measure_dut_switch_fn_failure_propagates(self):
+        """A failed switch aborts before the S11 sweep — a silent
+        proceed would record data on the wrong path. Verifies that the
+        sweep never runs and the switch was called exactly once with
+        the correct path."""
+        self.vna.setup(1e6, 250e6, 1000, 100, -5)
+        self.vna.switch_fn = MagicMock(side_effect=RuntimeError("switch boom"))
+        with patch.object(self.vna, "measure_S11") as m_s11:
+            with pytest.raises(RuntimeError, match="switch boom"):
+                self.vna.measure_dut("VNASP1")
+        self.vna.switch_fn.assert_called_once_with("VNASP1")
+        m_s11.assert_not_called()
 
     def test_read_data(self):
         """Test read_data method."""


### PR DESCRIPTION
## Summary

The new 16-path rfswitch PCB extends the hourly VNA observing cycle to include VNAAMB and VNASP1 paths. The existing per-path convenience methods (measure_ant, measure_rec) don't scale to 16 paths.

## Contract

`VNA.measure_dut(state)` routes the switch_fn to any PATHS name and returns one complex S11 sweep, matching the interface of measure_ant/measure_rec.

- Raises `RuntimeError` if switch_fn is None (same as measure_ant/measure_rec).
- Propagates exceptions from switch_fn, aborting before the S11 measurement (so failures don't record data on the wrong path).
- DummyVNA inherits it with no further change — the contract is upward-compatible.

## Follow-up

eigsep_observing's follow-up PR will pin `eigsep-vna>=1.4` and fold VNAAMB/VNASP1 into the VNA loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)