### PR TITLE
fix: revert to ASCII data transfer — cmtvna server ignores FORMat; S11 via SDAT

### DIFF
--- a/src/cmt_vna/testing.py
+++ b/src/cmt_vna/testing.py
@@ -20,6 +20,9 @@ class DummyResource:
         self._npoints = self._DEFAULT_NPOINTS
         self._fstart = self._DEFAULT_FSTART
         self._fstop = self._DEFAULT_FSTOP
+        # Real instruments default to ASCII transfer until FORM:DATA
+        # is written; binary-block queries fail in that state.
+        self._form_data = "ASC"
 
     def write(self, command):
         """Parse SCPI commands to track instrument state."""
@@ -33,6 +36,8 @@ class DummyResource:
         elif cmd.startswith("SENS1:SWE:POIN"):
             parts = cmd.split()
             self._npoints = int(float(parts[1]))
+        elif cmd.startswith("FORM:DATA "):
+            self._form_data = cmd.split(maxsplit=1)[1]
 
     def query(self, command):
         """Respond to simple SCPI queries."""
@@ -41,6 +46,8 @@ class DummyResource:
             return "DummyVNA"
         if cmd == "*OPC?":
             return "1"
+        if cmd == "FORM:DATA?":
+            return self._form_data
         raise ValueError(f"Query command {command!r} not recognized by mock.")
 
     def query_binary_values(
@@ -71,6 +78,14 @@ class DummyResource:
             Simulated data response from the VNA.
 
         """
+        if not self._form_data.startswith("REAL"):
+            # mimic pyvisa on hardware: an ASCII reply carries no IEEE
+            # block header, so binary parsing fails
+            raise ValueError(
+                'Could not find hash sign ("#") indicating the start '
+                "of the block: instrument data format is "
+                f"{self._form_data!r}"
+            )
         cmd = command.strip()
         if cmd == "CALC:TRAC:DATA:FDAT?":
             data = np.zeros(2 * self._npoints)
@@ -94,18 +109,17 @@ class DummyVNA(VNA):
     possible.
     """
 
-    def _configure_vna(self):
+    # Resource class to instantiate; tests override this to model
+    # cold-start / never-ready instrument servers.
+    _resource_cls = DummyResource
+
+    def _open_resource(self):
         """
-        Override _configure_vna to use DummyResource instead of real
-        PyVISA, while still exercising the SCPI initialization writes.
+        Override _open_resource to use DummyResource instead of real
+        PyVISA. The base class _configure_vna still runs, so the SCPI
+        config push and the verify loop are exercised for real.
         """
-        s = DummyResource()
+        s = self._resource_cls()
         s.read_termination = "\n"
         s.timeout = self.vna_timeout
-        s.write("CALC:FORM SCOM\n")
-        s.write("FORM:BORD NORM\n")
-        s.write("FORM:DATA REAL,64\n")
-        s.write("SENS1:AVER:COUN 1\n")
-        s.write("SWE:TYPE LIN\n")
-        s.write("TRIG:SOUR BUS\n")
         return s

--- a/src/cmt_vna/testing.py
+++ b/src/cmt_vna/testing.py
@@ -20,9 +20,6 @@ class DummyResource:
         self._npoints = self._DEFAULT_NPOINTS
         self._fstart = self._DEFAULT_FSTART
         self._fstop = self._DEFAULT_FSTOP
-        # Real instruments default to ASCII transfer until FORM:DATA
-        # is written; binary-block queries fail in that state.
-        self._form_data = "ASC"
 
     def write(self, command):
         """Parse SCPI commands to track instrument state."""
@@ -36,15 +33,8 @@ class DummyResource:
         elif cmd.startswith("SENS1:SWE:POIN"):
             parts = cmd.split()
             self._npoints = int(float(parts[1]))
-        elif cmd.startswith("FORM:DATA "):
-            # per the RVNA SCPI manual, only ASCii|REAL|REAL32 are
-            # valid; out-of-range values (e.g. Keysight-style
-            # "REAL,64") mean "the command is ignored". The query
-            # echo set is {ASC|REAL|REAL32}.
-            value = cmd.split(maxsplit=1)[1].strip().upper()
-            echo = {"ASC": "ASC", "ASCII": "ASC"}.get(value, value)
-            if echo in ("ASC", "REAL", "REAL32"):
-                self._form_data = echo
+        # like the Linux cmtvna server, unrecognized writes (notably
+        # the whole FORMat subsystem) are silently ignored
 
     def query(self, command):
         """Respond to simple SCPI queries."""
@@ -53,18 +43,16 @@ class DummyResource:
             return "DummyVNA"
         if cmd == "*OPC?":
             return "1"
-        if cmd == "FORM:DATA?":
-            return self._form_data
         raise ValueError(f"Query command {command!r} not recognized by mock.")
 
-    def query_binary_values(
-        self, command, datatype="d", is_big_endian=True, container=None
-    ):
+    def query_ascii_values(self, command, container=list):
         """
-        Simulate querying binary array data from the VNA.
+        Simulate querying ASCII array data from the VNA — the only
+        transfer format the Linux cmtvna server supports (it ignores
+        the FORMat subsystem, so binary transfer is unavailable).
 
         Supports:
-        - CALC:TRAC:DATA:FDAT? : interleaved real/imag S11 data
+        - CALC:DATA:SDAT? : interleaved real/imag S11 data
           (2 * npoints values, all zeros)
         - SENS1:FREQ:DATA? : frequency array (npoints values)
 
@@ -72,11 +60,7 @@ class DummyResource:
         ----------
         command : str
             SCPI query command.
-        datatype : str
-            Data type format character (ignored in mock).
-        is_big_endian : bool
-            Byte order (ignored in mock).
-        container : callable or None
+        container : callable
             Container for the returned data (e.g. np.array).
 
         Returns
@@ -85,24 +69,14 @@ class DummyResource:
             Simulated data response from the VNA.
 
         """
-        if not self._form_data.startswith("REAL"):
-            # mimic pyvisa on hardware: an ASCII reply carries no IEEE
-            # block header, so binary parsing fails
-            raise ValueError(
-                'Could not find hash sign ("#") indicating the start '
-                "of the block: instrument data format is "
-                f"{self._form_data!r}"
-            )
         cmd = command.strip()
-        if cmd == "CALC:TRAC:DATA:FDAT?":
+        if cmd == "CALC:DATA:SDAT?":
             data = np.zeros(2 * self._npoints)
         elif cmd == "SENS1:FREQ:DATA?":
             data = np.linspace(self._fstart, self._fstop, self._npoints)
         else:
             raise ValueError(f"Command {command!r} not recognized by mock.")
-        if container is not None:
-            data = container(data)
-        return data
+        return container(data)
 
     def close(self):
         pass

--- a/src/cmt_vna/testing.py
+++ b/src/cmt_vna/testing.py
@@ -37,7 +37,14 @@ class DummyResource:
             parts = cmd.split()
             self._npoints = int(float(parts[1]))
         elif cmd.startswith("FORM:DATA "):
-            self._form_data = cmd.split(maxsplit=1)[1]
+            # per the RVNA SCPI manual, only ASCii|REAL|REAL32 are
+            # valid; out-of-range values (e.g. Keysight-style
+            # "REAL,64") mean "the command is ignored". The query
+            # echo set is {ASC|REAL|REAL32}.
+            value = cmd.split(maxsplit=1)[1].strip().upper()
+            echo = {"ASC": "ASC", "ASCII": "ASC"}.get(value, value)
+            if echo in ("ASC", "REAL", "REAL32"):
+                self._form_data = echo
 
     def query(self, command):
         """Respond to simple SCPI queries."""

--- a/src/cmt_vna/vna.py
+++ b/src/cmt_vna/vna.py
@@ -34,6 +34,14 @@ def mlin(x):
 
 
 class VNA:
+    # A cold-started instrument server answers *IDN? before its
+    # measurement application processes configuration writes; writes
+    # sent in that window are silently dropped. _verify_config
+    # re-pushes the configuration until the instrument echoes it back,
+    # giving up after CONFIG_VERIFY_TIMEOUT_S.
+    CONFIG_VERIFY_TIMEOUT_S = 30.0
+    CONFIG_VERIFY_INTERVAL_S = 1.0
+
     def __init__(
         self,
         ip=IP,
@@ -88,9 +96,9 @@ class VNA:
         self.vna_timeout = timeout * 1e3  # convert to milliseconds
         self.s = self._configure_vna()
 
-    def _configure_vna(self):
+    def _open_resource(self):
         """
-        Use pyvisa to connect to the VNA and configure it.
+        Use pyvisa to open the socket resource to the VNA.
 
         Returns
         -------
@@ -103,8 +111,21 @@ class VNA:
         s = rm.open_resource(cmd)
         s.read_termination = "\n"
         s.timeout = self.vna_timeout
+        return s
 
-        # settings
+    def _push_config(self, s):
+        """
+        Write the measurement configuration to the VNA.
+
+        Writes are fire-and-forget; _verify_config confirms the
+        instrument applied them.
+
+        Parameters
+        ----------
+        s : pyvisa.Resource
+            Opened resource to the VNA.
+
+        """
         s.write("CALC:FORM SCOM\n")  # get s11 as real and imag
         s.write("FORM:BORD NORM\n")  # big-endian binary transfer
         s.write("FORM:DATA REAL,64\n")  # 64-bit binary transfer
@@ -112,6 +133,64 @@ class VNA:
         # linear sweep instead of point by point
         s.write("SWE:TYPE LIN\n")
         s.write("TRIG:SOUR BUS\n")
+
+    def _verify_config(self, s):
+        """
+        Block until the VNA echoes the pushed configuration back.
+
+        A cold-started instrument server answers ``*IDN?`` before its
+        measurement application is ready; configuration writes sent in
+        that window are silently dropped, leaving the default ASCII
+        data format and breaking every binary-block query.
+        ``FORM:DATA?`` is the sentinel: once it echoes ``REAL``, the
+        configuration burst was processed. On a mismatch the full
+        burst is re-pushed — the writes travel together, so one
+        dropped write means the whole burst must be repeated.
+
+        Parameters
+        ----------
+        s : pyvisa.Resource
+            Opened resource to the VNA.
+
+        Raises
+        ------
+        RuntimeError
+            If the instrument does not echo the configuration within
+            CONFIG_VERIFY_TIMEOUT_S seconds.
+
+        """
+        deadline = time.monotonic() + self.CONFIG_VERIFY_TIMEOUT_S
+        while True:
+            try:
+                reply = s.query("FORM:DATA?\n").strip().upper()
+            except pyvisa.VisaIOError:
+                reply = None  # not serving queries yet; retry below
+            if reply is not None and reply.replace(" ", "").startswith("REAL"):
+                return
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    "VNA did not accept configuration within "
+                    f"{self.CONFIG_VERIFY_TIMEOUT_S:.0f} s (last "
+                    f"FORM:DATA? reply: {reply!r}); is the instrument "
+                    "server still starting?"
+                )
+            time.sleep(self.CONFIG_VERIFY_INTERVAL_S)
+            self._push_config(s)
+
+    def _configure_vna(self):
+        """
+        Connect to the VNA, configure it, and verify the configuration
+        was applied.
+
+        Returns
+        -------
+        s : pyvisa.Resource
+            Opened resource to the VNA.
+
+        """
+        s = self._open_resource()
+        self._push_config(s)
+        self._verify_config(s)
         return s
 
     @property

--- a/src/cmt_vna/vna.py
+++ b/src/cmt_vna/vna.py
@@ -34,14 +34,6 @@ def mlin(x):
 
 
 class VNA:
-    # A cold-started instrument server answers *IDN? before its
-    # measurement application processes configuration writes; writes
-    # sent in that window are silently dropped. _verify_config
-    # re-pushes the configuration until the instrument echoes it back,
-    # giving up after CONFIG_VERIFY_TIMEOUT_S.
-    CONFIG_VERIFY_TIMEOUT_S = 30.0
-    CONFIG_VERIFY_INTERVAL_S = 1.0
-
     def __init__(
         self,
         ip=IP,
@@ -117,8 +109,14 @@ class VNA:
         """
         Write the measurement configuration to the VNA.
 
-        Writes are fire-and-forget; _verify_config confirms the
-        instrument applied them.
+        Data transfer stays in the instrument's ASCII preset: the
+        Linux cmtvna socket server ignores the FORMat subsystem —
+        FORM:DATA writes are no-ops and FORM:DATA? is never answered
+        (verified on the R60, server 1.7.1, 2026-07-08) — so binary
+        transfer is unavailable and all array reads use
+        ``query_ascii_values``. CALC:FORM is likewise not relied on:
+        S11 reads use ``CALC:DATA:SDAT?``, which returns complex
+        re/im pairs independent of the display format.
 
         Parameters
         ----------
@@ -126,67 +124,14 @@ class VNA:
             Opened resource to the VNA.
 
         """
-        s.write("CALC:FORM SCOM\n")  # get s11 as real and imag
-        s.write("FORM:BORD NORM\n")  # big-endian binary transfer
-        # 64-bit binary transfer. CMT accepts only ASCii|REAL|REAL32
-        # (REAL = IEEE-64); anything else — e.g. the Keysight-style
-        # "REAL,64" — is documented as "the command is ignored",
-        # leaving the preset ASCII format.
-        s.write("FORM:DATA REAL\n")
         s.write("SENS1:AVER:COUN 1\n")  # number of averages
         # linear sweep instead of point by point
         s.write("SWE:TYPE LIN\n")
         s.write("TRIG:SOUR BUS\n")
 
-    def _verify_config(self, s):
-        """
-        Block until the VNA echoes the pushed configuration back.
-
-        A cold-started instrument server answers ``*IDN?`` before its
-        measurement application is ready; configuration writes sent in
-        that window are silently dropped, leaving the default ASCII
-        data format and breaking every binary-block query.
-        ``FORM:DATA?`` is the sentinel: once it echoes exactly
-        ``REAL`` (the manual's query response set is
-        ``{ASC|REAL|REAL32}``), the configuration burst was processed.
-        On a mismatch the full burst is re-pushed — the writes travel
-        together, so one dropped write means the whole burst must be
-        repeated.
-
-        Parameters
-        ----------
-        s : pyvisa.Resource
-            Opened resource to the VNA.
-
-        Raises
-        ------
-        RuntimeError
-            If the instrument does not echo the configuration within
-            CONFIG_VERIFY_TIMEOUT_S seconds.
-
-        """
-        deadline = time.monotonic() + self.CONFIG_VERIFY_TIMEOUT_S
-        while True:
-            try:
-                reply = s.query("FORM:DATA?\n").strip().upper()
-            except pyvisa.VisaIOError:
-                reply = None  # not serving queries yet; retry below
-            if reply == "REAL":
-                return
-            if time.monotonic() >= deadline:
-                raise RuntimeError(
-                    "VNA did not accept configuration within "
-                    f"{self.CONFIG_VERIFY_TIMEOUT_S:.0f} s (last "
-                    f"FORM:DATA? reply: {reply!r}); is the instrument "
-                    "server still starting?"
-                )
-            time.sleep(self.CONFIG_VERIFY_INTERVAL_S)
-            self._push_config(s)
-
     def _configure_vna(self):
         """
-        Connect to the VNA, configure it, and verify the configuration
-        was applied.
+        Connect to the VNA and configure it.
 
         Returns
         -------
@@ -196,7 +141,6 @@ class VNA:
         """
         s = self._open_resource()
         self._push_config(s)
-        self._verify_config(s)
         return s
 
     @property
@@ -260,11 +204,10 @@ class VNA:
 
     @property
     def freqs(self):
-        return self.s.query_binary_values(
-            "SENS1:FREQ:DATA?",
-            datatype="d",
-            is_big_endian=True,
-            container=np.array,
+        # ASCII transfer: the server ignores FORM:DATA (see
+        # _push_config), so binary-block reads are unavailable
+        return self.s.query_ascii_values(
+            "SENS1:FREQ:DATA?", container=np.array
         )
 
     @property
@@ -365,12 +308,11 @@ class VNA:
         self.wait_for_opc()  # wait for operation complete
         if verbose:
             print("swept")
-        data = self.s.query_binary_values(
-            "CALC:TRAC:DATA:FDAT?",
-            datatype="d",
-            is_big_endian=True,
-            container=np.array,
-        )
+        # SDAT (not FDAT): complex S-parameter re/im pairs regardless
+        # of display format, so no dependence on CALC:FORM — which the
+        # server may ignore just like FORM:DATA. ASCII per
+        # _push_config.
+        data = self.s.query_ascii_values("CALC:DATA:SDAT?", container=np.array)
         self.wait_for_opc()  # wait for operation complete
         if verbose:
             sweep_time = time.time() - t0

--- a/src/cmt_vna/vna.py
+++ b/src/cmt_vna/vna.py
@@ -128,7 +128,11 @@ class VNA:
         """
         s.write("CALC:FORM SCOM\n")  # get s11 as real and imag
         s.write("FORM:BORD NORM\n")  # big-endian binary transfer
-        s.write("FORM:DATA REAL,64\n")  # 64-bit binary transfer
+        # 64-bit binary transfer. CMT accepts only ASCii|REAL|REAL32
+        # (REAL = IEEE-64); anything else — e.g. the Keysight-style
+        # "REAL,64" — is documented as "the command is ignored",
+        # leaving the preset ASCII format.
+        s.write("FORM:DATA REAL\n")
         s.write("SENS1:AVER:COUN 1\n")  # number of averages
         # linear sweep instead of point by point
         s.write("SWE:TYPE LIN\n")
@@ -142,10 +146,12 @@ class VNA:
         measurement application is ready; configuration writes sent in
         that window are silently dropped, leaving the default ASCII
         data format and breaking every binary-block query.
-        ``FORM:DATA?`` is the sentinel: once it echoes ``REAL``, the
-        configuration burst was processed. On a mismatch the full
-        burst is re-pushed — the writes travel together, so one
-        dropped write means the whole burst must be repeated.
+        ``FORM:DATA?`` is the sentinel: once it echoes exactly
+        ``REAL`` (the manual's query response set is
+        ``{ASC|REAL|REAL32}``), the configuration burst was processed.
+        On a mismatch the full burst is re-pushed — the writes travel
+        together, so one dropped write means the whole burst must be
+        repeated.
 
         Parameters
         ----------
@@ -165,7 +171,7 @@ class VNA:
                 reply = s.query("FORM:DATA?\n").strip().upper()
             except pyvisa.VisaIOError:
                 reply = None  # not serving queries yet; retry below
-            if reply is not None and reply.replace(" ", "").startswith("REAL"):
+            if reply == "REAL":
                 return
             if time.monotonic() >= deadline:
                 raise RuntimeError(

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -1,6 +1,5 @@
 import numpy as np
 from pathlib import Path
-import pyvisa
 import pytest
 import tempfile
 import time
@@ -565,108 +564,30 @@ class TestActiveFlag:
             assert high is None or isinstance(high, (int, float))
 
 
-class ColdStartResource(DummyResource):
+class TestAsciiTransfer:
     """
-    Models a cold-started instrument server (on-demand cmtvna.service):
-    the SCPI front-end answers queries but the measurement app drops
-    every write until the first query round-trip completes — the
-    failure mode observed on hardware, where the initial config burst
-    was lost and SENS1:FREQ:DATA? came back ASCII.
+    Array reads must be ASCII: the Linux cmtvna socket server ignores
+    the FORMat subsystem (FORM:DATA writes are no-ops, FORM:DATA? is
+    never answered — verified on the R60, server 1.7.1, 2026-07-08),
+    so binary-block transfer is unavailable. S11 reads use
+    CALC:DATA:SDAT? because it returns complex re/im pairs regardless
+    of the display format (CALC:FORM may be ignored the same way).
     """
 
-    def __init__(self):
-        super().__init__()
-        self.ready = False
-        self.write_count = 0
-
-    def write(self, command):
-        self.write_count += 1
-        if self.ready:
-            super().write(command)
-
-    def query(self, command):
-        reply = super().query(command)
-        # the app finishes initializing while the driver waits for
-        # this first echo; subsequent writes land
-        self.ready = True
-        return reply
-
-
-class NeverReadyResource(ColdStartResource):
-    """Drops every write forever: configuration can never land."""
-
-    def query(self, command):
-        return DummyResource.query(self, command)
-
-
-class TimeoutThenReadyResource(DummyResource):
-    """First query times out (VisaIOError), then behaves normally."""
-
-    def __init__(self):
-        super().__init__()
-        self._timeouts_left = 1
-
-    def query(self, command):
-        if self._timeouts_left:
-            self._timeouts_left -= 1
-            raise pyvisa.VisaIOError(pyvisa.constants.StatusCode.error_timeout)
-        return super().query(command)
-
-
-class ColdStartVNA(DummyVNA):
-    CONFIG_VERIFY_INTERVAL_S = 0.0
-    _resource_cls = ColdStartResource
-
-
-class NeverReadyVNA(DummyVNA):
-    CONFIG_VERIFY_TIMEOUT_S = 0.05
-    CONFIG_VERIFY_INTERVAL_S = 0.0
-    _resource_cls = NeverReadyResource
-
-
-class TimeoutOnceVNA(DummyVNA):
-    CONFIG_VERIFY_INTERVAL_S = 0.0
-    _resource_cls = TimeoutThenReadyResource
-
-
-class TestConfigVerify:
-    """Connect-time config verification (cold-start write drop)."""
-
-    def test_binary_query_on_unconfigured_instrument_fails(self):
-        # contract fidelity: a fresh instrument defaults to ASCII, so
-        # binary-block queries must fail exactly like pyvisa does on
-        # hardware
-        s = DummyResource()
-        with pytest.raises(ValueError, match="hash sign"):
-            s.query_binary_values("SENS1:FREQ:DATA?")
-
-    def test_warm_instrument_configures_first_try(self):
+    def test_freqs_is_ascii_read(self):
         vna = DummyVNA()
-        assert vna.s._form_data == "REAL"
+        vna.setup(npoints=101)
+        freqs = vna.freqs
+        assert len(freqs) == 101
 
-    def test_cold_start_config_is_repushed(self):
-        vna = ColdStartVNA()
-        # first burst (6 writes) dropped, second burst landed
-        assert vna.s.write_count == 12
-        assert vna.s._form_data == "REAL"
-        # the recovered instrument serves binary queries
-        freqs = vna.setup()
-        assert len(freqs) == vna.npoints
+    def test_measure_s11_deinterleaves_sdat(self):
+        vna = DummyVNA()
+        vna.setup(npoints=101)
+        data = vna.measure_S11()
+        assert np.iscomplexobj(data)
+        assert len(data) == 101
 
-    def test_never_ready_raises_with_last_reply(self):
-        with pytest.raises(RuntimeError, match="FORM:DATA. reply: 'ASC'"):
-            NeverReadyVNA()
-
-    def test_query_timeout_during_verify_is_retried(self):
-        vna = TimeoutOnceVNA()
-        assert vna.s._form_data == "REAL"
-
-    def test_keysight_style_format_value_is_ignored(self):
-        # regression guard for the field failure: CMT documents
-        # out-of-range FORM:DATA values as "the command is ignored",
-        # so the Keysight-style "REAL,64" strands a fresh server in
-        # its ASCII preset. A driver writing it can't pass
-        # _verify_config against this dummy.
-        s = DummyResource()
-        s.write("FORM:DATA REAL,64\n")
-        assert s._form_data == "ASC"
+    def test_dummy_resource_has_no_binary_path(self):
+        # the driver must not regress to binary reads: the dummy, like
+        # the real server, only serves ASCII
+        assert not hasattr(DummyResource(), "query_binary_values")

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -1,12 +1,13 @@
 import numpy as np
 from pathlib import Path
+import pyvisa
 import pytest
 import tempfile
 import time
 from unittest.mock import MagicMock, call, patch
 
 from cmt_vna.vna import IP, PORT, DEFAULT_FLAG_THRESHOLDS, lin2dB, mlin
-from cmt_vna.testing import DummyVNA
+from cmt_vna.testing import DummyResource, DummyVNA
 
 
 class TestDummyVNA:
@@ -562,3 +563,100 @@ class TestActiveFlag:
             low, high = DEFAULT_FLAG_THRESHOLDS[key]
             assert low is None or isinstance(low, (int, float))
             assert high is None or isinstance(high, (int, float))
+
+
+class ColdStartResource(DummyResource):
+    """
+    Models a cold-started instrument server (on-demand cmtvna.service):
+    the SCPI front-end answers queries but the measurement app drops
+    every write until the first query round-trip completes — the
+    failure mode observed on hardware, where the initial config burst
+    was lost and SENS1:FREQ:DATA? came back ASCII.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.ready = False
+        self.write_count = 0
+
+    def write(self, command):
+        self.write_count += 1
+        if self.ready:
+            super().write(command)
+
+    def query(self, command):
+        reply = super().query(command)
+        # the app finishes initializing while the driver waits for
+        # this first echo; subsequent writes land
+        self.ready = True
+        return reply
+
+
+class NeverReadyResource(ColdStartResource):
+    """Drops every write forever: configuration can never land."""
+
+    def query(self, command):
+        return DummyResource.query(self, command)
+
+
+class TimeoutThenReadyResource(DummyResource):
+    """First query times out (VisaIOError), then behaves normally."""
+
+    def __init__(self):
+        super().__init__()
+        self._timeouts_left = 1
+
+    def query(self, command):
+        if self._timeouts_left:
+            self._timeouts_left -= 1
+            raise pyvisa.VisaIOError(pyvisa.constants.StatusCode.error_timeout)
+        return super().query(command)
+
+
+class ColdStartVNA(DummyVNA):
+    CONFIG_VERIFY_INTERVAL_S = 0.0
+    _resource_cls = ColdStartResource
+
+
+class NeverReadyVNA(DummyVNA):
+    CONFIG_VERIFY_TIMEOUT_S = 0.05
+    CONFIG_VERIFY_INTERVAL_S = 0.0
+    _resource_cls = NeverReadyResource
+
+
+class TimeoutOnceVNA(DummyVNA):
+    CONFIG_VERIFY_INTERVAL_S = 0.0
+    _resource_cls = TimeoutThenReadyResource
+
+
+class TestConfigVerify:
+    """Connect-time config verification (cold-start write drop)."""
+
+    def test_binary_query_on_unconfigured_instrument_fails(self):
+        # contract fidelity: a fresh instrument defaults to ASCII, so
+        # binary-block queries must fail exactly like pyvisa does on
+        # hardware
+        s = DummyResource()
+        with pytest.raises(ValueError, match="hash sign"):
+            s.query_binary_values("SENS1:FREQ:DATA?")
+
+    def test_warm_instrument_configures_first_try(self):
+        vna = DummyVNA()
+        assert vna.s._form_data == "REAL,64"
+
+    def test_cold_start_config_is_repushed(self):
+        vna = ColdStartVNA()
+        # first burst (6 writes) dropped, second burst landed
+        assert vna.s.write_count == 12
+        assert vna.s._form_data == "REAL,64"
+        # the recovered instrument serves binary queries
+        freqs = vna.setup()
+        assert len(freqs) == vna.npoints
+
+    def test_never_ready_raises_with_last_reply(self):
+        with pytest.raises(RuntimeError, match="FORM:DATA. reply: 'ASC'"):
+            NeverReadyVNA()
+
+    def test_query_timeout_during_verify_is_retried(self):
+        vna = TimeoutOnceVNA()
+        assert vna.s._form_data == "REAL,64"

--- a/tests/test_vna.py
+++ b/tests/test_vna.py
@@ -642,13 +642,13 @@ class TestConfigVerify:
 
     def test_warm_instrument_configures_first_try(self):
         vna = DummyVNA()
-        assert vna.s._form_data == "REAL,64"
+        assert vna.s._form_data == "REAL"
 
     def test_cold_start_config_is_repushed(self):
         vna = ColdStartVNA()
         # first burst (6 writes) dropped, second burst landed
         assert vna.s.write_count == 12
-        assert vna.s._form_data == "REAL,64"
+        assert vna.s._form_data == "REAL"
         # the recovered instrument serves binary queries
         freqs = vna.setup()
         assert len(freqs) == vna.npoints
@@ -659,4 +659,14 @@ class TestConfigVerify:
 
     def test_query_timeout_during_verify_is_retried(self):
         vna = TimeoutOnceVNA()
-        assert vna.s._form_data == "REAL,64"
+        assert vna.s._form_data == "REAL"
+
+    def test_keysight_style_format_value_is_ignored(self):
+        # regression guard for the field failure: CMT documents
+        # out-of-range FORM:DATA values as "the command is ignored",
+        # so the Keysight-style "REAL,64" strands a fresh server in
+        # its ASCII preset. A driver writing it can't pass
+        # _verify_config against this dummy.
+        s = DummyResource()
+        s.write("FORM:DATA REAL,64\n")
+        assert s._form_data == "ASC"


### PR DESCRIPTION
## Summary

Fixes the field failure with the on-demand `cmtvna.service`:

```
ValueError: Could not find hash sign ("#") indicating the start of the block.
The block begins with bytearray(b'+1.0000000000E+06,+1.2492')
```

**Root cause (established by live SCPI probing on the panda Pi — R60, Linux cmtvna server 1.7.1/3):** the aarch64 socket server **ignores the `FORMat` subsystem entirely** — `FORM:DATA REAL` is a no-op (functionally verified: binary read still gets ASCII afterwards) and `FORM:DATA?` is never answered (times out). Binary-block transfer is simply unavailable on this server. The March switch to binary transfer (e4b6430 + 7e817f8) predates the aarch64 server era, so **binary mode never worked on the Pi stack** — this was the first real S11 attempt to exercise it. All 2025 production data used ASCII transfer.

## What changed

- **ASCII reads restored** (the 2025-proven path): `freqs` and `measure_S11` use `query_ascii_values`.
- **S11 via `CALC:DATA:SDAT?`** instead of `CALC:TRAC:DATA:FDAT?`: SDAT returns complex re/im pairs independent of display format (probed: 2×NOP values with the display in SCOM *and* MLOG), removing the dependence on `CALC:FORM` — which the server may ignore just like `FORM:DATA`.
- **Dead config writes dropped**: `CALC:FORM SCOM`, `FORM:BORD NORM`, `FORM:DATA REAL,64` are gone (all ignored by the server; the last one was also invalid syntax per the RVNA manual — "Out of Range: the command is ignored").
- **Connect-time verify loop removed** — it existed to guard the format configuration, which no longer exists; its `FORM:DATA?` sentinel was also what hung the constructor for the full 1000 s socket timeout on the previous iteration of this branch.
- **`DummyResource` mirrors the real server contract**: ASCII-only array replies via `query_ascii_values` (`SDAT` + frequency grid), **no `query_binary_values` at all** — a driver regression to binary reads fails the suite — and unrecognized writes silently ignored. `DummyVNA` overrides only `_open_resource`, so the config-push path runs through the dummy (removes the previously duplicated writes).

## Hardware evidence (IPython on the Pi, server 1.7.1/3)

- `*IDN?` → answers; `FORM:DATA?` → timeout (before *and* after writing `FORM:DATA REAL`)
- binary `SENS1:FREQ:DATA?` after `FORM:DATA REAL` → still ASCII (hash-sign ValueError)
- `query_ascii_values("SENS1:FREQ:DATA?")` → 201 points ✓
- `CALC:TRAC:DATA:FDAT?` → 402 values in SCOM and MLOG (length can't distinguish whether CALC:FORM is honored)
- `CALC:DATA:SDAT?` → 402 values (complex pairs, format-independent) ✓

## Testing

- Full suite: **57 passed**, ruff clean.
- New `TestAsciiTransfer` class: ASCII freqs read, SDAT de-interleave to complex, and a regression guard that the dummy (like the server) has no binary path.
- Remaining hardware validation: one cold end-to-end `vna_manual.py` session on the Pi (exercises the `TRIG:SEQ:SING` + `*OPC?` sweep flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)